### PR TITLE
Add document parsing and chunking utilities

### DIFF
--- a/backend/app/core/chunking.py
+++ b/backend/app/core/chunking.py
@@ -1,0 +1,118 @@
+"""Utilities for splitting text into semantic chunks."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class ChunkMetadata:
+    text: str
+    index: int
+    start_char: int
+    end_char: int
+    token_count: int
+
+    def as_dict(self) -> Dict[str, int | str]:
+        return {
+            "text": self.text,
+            "index": self.index,
+            "start_char": self.start_char,
+            "end_char": self.end_char,
+            "token_count": self.token_count,
+        }
+
+
+class TextChunker:
+    """Break text into overlapping chunks while keeping sentence boundaries."""
+
+    sentence_pattern = re.compile(r"[^.!?]+(?:[.!?]+|$)", re.MULTILINE | re.DOTALL)
+
+    def chunk(
+        self, text: str, chunk_size: int = 512, overlap: int = 50
+    ) -> List[Dict[str, int | str]]:
+        if not text:
+            return []
+
+        sentences = self._split_into_sentences(text)
+
+        chunks: List[ChunkMetadata] = []
+        current: List[Dict[str, int | str]] = []
+        current_tokens = 0
+
+        for sentence in sentences:
+            sent_tokens = sentence["tokens"]
+
+            if current and current_tokens + sent_tokens > chunk_size:
+                chunks.append(self._finalize_chunk(current, len(chunks)))
+                current, current_tokens = self._apply_overlap(current, overlap)
+
+            current.append(sentence)
+            current_tokens += sent_tokens
+
+        if current:
+            chunks.append(self._finalize_chunk(current, len(chunks)))
+
+        return [chunk.as_dict() for chunk in chunks]
+
+    def _split_into_sentences(self, text: str) -> List[Dict[str, int | str]]:
+        sentences: List[Dict[str, int | str]] = []
+        for match in self.sentence_pattern.finditer(text):
+            sentence_text = match.group().strip()
+            if not sentence_text:
+                continue
+
+            start = match.start()
+            end = match.end()
+            tokens = self._estimate_tokens(sentence_text)
+            sentences.append(
+                {
+                    "text": sentence_text,
+                    "start": start,
+                    "end": end,
+                    "tokens": tokens,
+                }
+            )
+
+        if not sentences:
+            sentences.append(
+                {
+                    "text": text.strip(),
+                    "start": 0,
+                    "end": len(text),
+                    "tokens": self._estimate_tokens(text),
+                }
+            )
+        return sentences
+
+    def _apply_overlap(
+        self, sentences: List[Dict[str, int | str]], overlap: int
+    ) -> tuple[List[Dict[str, int | str]], int]:
+        overlap_sentences: List[Dict[str, int | str]] = []
+        tokens = 0
+
+        for sentence in reversed(sentences):
+            overlap_sentences.insert(0, sentence)
+            tokens += sentence["tokens"]
+            if tokens >= overlap:
+                break
+
+        return overlap_sentences, tokens
+
+    def _finalize_chunk(
+        self, sentences: List[Dict[str, int | str]], index: int
+    ) -> ChunkMetadata:
+        text = " ".join(sentence["text"] for sentence in sentences).strip()
+        start_char = sentences[0]["start"]
+        end_char = sentences[-1]["end"]
+        token_count = sum(sentence["tokens"] for sentence in sentences)
+        return ChunkMetadata(text, index, start_char, end_char, token_count)
+
+    def _estimate_tokens(self, text: str) -> int:
+        words = re.findall(r"\w+", text)
+        approx = len(words) * 1.3
+        return max(1, int(math.ceil(approx)))
+

--- a/backend/app/core/parser.py
+++ b/backend/app/core/parser.py
@@ -1,0 +1,103 @@
+"""Document parsing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import List
+
+from pypdf import PdfReader
+
+
+class DocumentParser:
+    """Parse documents into page-like chunks of text."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+        self.last_file_hash: str | None = None
+
+    def parse(self, file_path: str | Path) -> List[str]:
+        """Parse the provided file and return a list of page texts.
+
+        Args:
+            file_path: Path to the file that should be parsed.
+
+        Returns:
+            A list of strings where each string represents a page of text.
+
+        Raises:
+            FileNotFoundError: If the provided file path does not exist.
+            ValueError: If the file type is not supported.
+            RuntimeError: If an unexpected error occurs during parsing.
+        """
+
+        path = Path(file_path)
+
+        if not path.exists():
+            self.logger.error("File not found: %s", path)
+            raise FileNotFoundError(f"File not found: {path}")
+
+        file_hash = self._compute_hash(path)
+
+        try:
+            suffix = path.suffix.lower()
+            if suffix == ".pdf":
+                pages = self._parse_pdf(path)
+            elif suffix in {".txt", ".md"}:
+                pages = self._parse_text_file(path)
+            else:
+                self.logger.error("Unsupported file extension: %s", suffix)
+                raise ValueError(f"Unsupported file type: {suffix}")
+        except (FileNotFoundError, ValueError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.exception("Failed to parse file %s", path)
+            raise RuntimeError(f"Failed to parse file {path}") from exc
+
+        self.last_file_hash = file_hash
+        self.logger.debug(
+            "Parsed %s into %d page(s). Hash: %s", path, len(pages), file_hash
+        )
+        return pages
+
+    def _parse_pdf(self, path: Path) -> List[str]:
+        reader = PdfReader(str(path))
+        pages: List[str] = []
+        for index, page in enumerate(reader.pages):
+            try:
+                text = page.extract_text() or ""
+            except Exception:  # pragma: no cover - depends on PDF contents
+                self.logger.exception("Failed to extract text from PDF page %d", index)
+                text = ""
+
+            pages.append(text.strip())
+
+        if not pages:
+            self.logger.warning("No text extracted from PDF: %s", path)
+        return pages
+
+    def _parse_text_file(self, path: Path) -> List[str]:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            content = handle.read()
+
+        if not content:
+            self.logger.warning("Empty text document: %s", path)
+            return []
+
+        return self._split_text(content)
+
+    def _split_text(self, text: str, page_size: int = 3000) -> List[str]:
+        pages: List[str] = []
+        for start in range(0, len(text), page_size):
+            end = start + page_size
+            pages.append(text[start:end].strip())
+        return pages
+
+    def _compute_hash(self, path: Path, chunk_size: int = 8192) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as file_handle:
+            for chunk in iter(lambda: file_handle.read(chunk_size), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+


### PR DESCRIPTION
## Summary
- add a document parser supporting PDF, TXT, and MD files with hashing and logging
- implement a sentence-aware text chunker with overlap and token metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e296502924832e82af5d619e8ad811